### PR TITLE
Development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.vercel

--- a/src/Components/PageLayout.tsx
+++ b/src/Components/PageLayout.tsx
@@ -11,13 +11,10 @@ import { setColors, setThemeMode } from '@/Shared/functions';
 
 import { styles as typescaleStyles } from "@material/web/typography/md-typescale-styles";
 
-const initialHue = typeof window !== 'undefined' ? parseInt(localStorage.getItem('hueValue') || '289') : 289;
-const initialTheme = typeof window !== 'undefined' ? localStorage.getItem('theme') as 'white' | 'dark' : 'dark';
-
 const PageLayout = ({ children }: { children: React.ReactNode }) => {
     const [themeChangerVisibility, setThemeChangerVisibility] = useState(false);
     const [hamburgerState, setHamburgerState] = useState(false);
-    const [hueVal, setHueVal] = useState(initialHue);
+    const [hueVal, setHueVal] = useState(0);
 
     const themeChangerClick = () => setThemeChangerVisibility(!themeChangerVisibility);
     const hamburgerClick = () => setHamburgerState(!hamburgerState);
@@ -26,9 +23,10 @@ const PageLayout = ({ children }: { children: React.ReactNode }) => {
         if (typescaleStyles.styleSheet)
             document.adoptedStyleSheets.push(typescaleStyles.styleSheet);
 
-        setHueVal(parseInt(localStorage.getItem('hueValue') || '289'));
-        setThemeMode(initialTheme);
-        setColors(hueVal);
+        const hueLocal = parseInt(localStorage.getItem('hueValue') || '289');
+        setHueVal(hueLocal);
+        setThemeMode(localStorage.getItem('theme') as 'white' | 'dark' | null || 'dark');
+        setColors(hueLocal);
     }, []);
 
     return (


### PR DESCRIPTION
This pull request includes changes to the `PageLayout` component in `src/Components/PageLayout.tsx` to improve the initialization and setting of theme and hue values. The key changes involve refactoring how initial values are set and simplifying the state initialization.

Initialization improvements:

* Removed the `initialHue` and `initialTheme` constants and directly set the initial state values within the `useEffect` hook. [[1]](diffhunk://#diff-f9df04fe0489560f0a76504488ddfe0da8b5d581b9deb5f7fcecd194a8e144fdL14-R17) [[2]](diffhunk://#diff-f9df04fe0489560f0a76504488ddfe0da8b5d581b9deb5f7fcecd194a8e144fdL29-R29)
* Simplified the state initialization for `hueVal` by setting it to `0` initially and updating it within the `useEffect` hook.
* Adjusted the `setThemeMode` call to handle a possible `null` value from `localStorage` and set a default value of `'dark'`.